### PR TITLE
Important fix wrong counting in XML causes an 500 error when calling …

### DIFF
--- a/DokuwikiXMLExport.php
+++ b/DokuwikiXMLExport.php
@@ -59,7 +59,8 @@ class DokuwikiXMLExport
         }
         $exporter = Exporter::create(Exporter::TYPE_XML, $count);
 
-        $total = count($pages);
+        // total -1 because the XML starts counting at 0 like an array
+        $total = count($pages) - 1;
 
         // The count can't be higher then the total number of pages.
         $count = min($total, $count);


### PR DESCRIPTION
Fix #15

@georgms please review.

This is a hotfix to fix an 500 error when calling the last step in the export.
Cause: Array starts counting at `0` but `count($pages)` at `1`.
Fix: The fix is to count -1, but maybe there is a better solution for this?