### PR TITLE
Fix call of config

### DIFF
--- a/DokuwikiXMLExport.php
+++ b/DokuwikiXMLExport.php
@@ -61,7 +61,7 @@ class DokuwikiXMLExport
         $indexer = new Doku_Indexer();
         $pagesAndDeletedPages = $indexer->getPages();
 
-        $excludedPages = $this->splitConfigToArray($conf['plugin']['findologicxmlexport']['excludePages']);
+        $excludedPages = $this->splitConfigToArray($this->conf['plugin']['findologicxmlexport']['excludePages']);
         $pages = null;
         foreach ($pagesAndDeletedPages as $page) {
             if (p_get_metadata($page)['description']) { // Only get pages with content


### PR DESCRIPTION
Fix #18 

@georgms please review.

When trying to exclude a page this will not work.

 * Cause: `$this->splitConfigToArray($conf['plugin']['findologicxmlexport']['excludePages']);`
The variable `$conf` does not exist, because it is set in the constructor and is wrongly called.

 * Fix: `$this->conf['plugin']['findologicxmlexport']['excludePages']);`
Call the variable from the constructor set for this.