### PR TITLE
Hotfix for is_int()

### DIFF
--- a/OutputXMLHelper.php
+++ b/OutputXMLHelper.php
@@ -54,10 +54,13 @@ class OutputXMLHelper
      *
      * @param $start int start value
      * @param $count int count value
+     * @param $type int ID of the type to check.
      * @return bool true if parameters are valid, else false
      */
-    public function paramsValid($start, $count)
+    public function paramsValid($start, $count, $type)
     {
+        $start = filter_var($start, $type);
+        $count = filter_var($count, $type);
         return (is_int($count) && is_int($start) && $start >= 0 && $count > 0);
     }
 
@@ -67,14 +70,10 @@ class OutputXMLHelper
      * @param $paramName string Name of the URL parameter
      * @param $defaultValue string Default value if _GET parameter is not set
      * @param $getParam array _GET param
-     * @param $type int ID of the type to check.
      * @return string value of the _GET parameter or default value if _GET parameter is not set
      */
-    public function getUrlParam($paramName, $defaultValue, $getParam, $type)
+    public function getUrlParam($paramName, $defaultValue, $getParam)
     {
-        if (filter_var($getParam[$paramName], $type) === false) {
-            $this->throwError();
-        }
         if (isset($getParam[$paramName])) {
             return htmlspecialchars($getParam[$paramName]);
         } else {

--- a/OutputXMLHelper.php
+++ b/OutputXMLHelper.php
@@ -50,6 +50,11 @@ class OutputXMLHelper
     const EXPORT_ERROR_CODE = 400;
 
     /**
+     * Error level for DokuWiki functions.
+     */
+    const ERROR_LEVEL = -1;
+
+    /**
      * Validates count and start values
      *
      * @param $start int start value
@@ -100,7 +105,7 @@ class OutputXMLHelper
      */
     public function throwError() {
         header(self::EXPORT_ERROR_HEADER, true, self::EXPORT_ERROR_CODE);
-        msg(self::EXPORT_ERROR_MESSAGE, -1);
+        msg(self::EXPORT_ERROR_MESSAGE, self::ERROR_LEVEL);
         html_msgarea();
     }
 

--- a/OutputXMLHelper.php
+++ b/OutputXMLHelper.php
@@ -67,10 +67,14 @@ class OutputXMLHelper
      * @param $paramName string Name of the URL parameter
      * @param $defaultValue string Default value if _GET parameter is not set
      * @param $getParam array _GET param
+     * @param $type int ID of the type to check.
      * @return string value of the _GET parameter or default value if _GET parameter is not set
      */
-    public function getUrlParam($paramName, $defaultValue, $getParam)
+    public function getUrlParam($paramName, $defaultValue, $getParam, $type)
     {
+        if (filter_var($getParam[$paramName], $type) === false) {
+            $this->throwError();
+        }
         if (isset($getParam[$paramName])) {
             return htmlspecialchars($getParam[$paramName]);
         } else {
@@ -90,5 +94,24 @@ class OutputXMLHelper
         global $conf;
         $dokuwikiXmlExport = new DokuwikiXMLExport($conf);
         return $dokuwikiXmlExport->generateXMLExport($start, $count);
+    }
+
+    /**
+     * Sets the export error header and prints an error message
+     */
+    public function throwError() {
+        header(self::EXPORT_ERROR_HEADER, true, self::EXPORT_ERROR_CODE);
+        die(self::EXPORT_ERROR_MESSAGE);
+    }
+
+    /**
+     * Sets export header and prints the XML.
+     *
+     * @param $start int start value
+     * @param $count int count value
+     */
+    public function printXml($start, $count) {
+        header(self::EXPORT_HEADER);
+        echo $this->getXml($start, $count);
     }
 }

--- a/OutputXMLHelper.php
+++ b/OutputXMLHelper.php
@@ -100,7 +100,8 @@ class OutputXMLHelper
      */
     public function throwError() {
         header(self::EXPORT_ERROR_HEADER, true, self::EXPORT_ERROR_CODE);
-        die(self::EXPORT_ERROR_MESSAGE);
+        msg(self::EXPORT_ERROR_MESSAGE, -1);
+        html_msgarea();
     }
 
     /**

--- a/_test/outputxmlhelper.test.php
+++ b/_test/outputxmlhelper.test.php
@@ -66,21 +66,22 @@ class outputxmlhelper_test extends DokuWikiTest
      *
      * @param integer $start Start value for Export call
      * @param integer $count Count value for Export call
-     * @dataProvider parameterProviderForXMLCallWithFloatParams
+     * @dataProvider parameterProviderForXMLCallWithFloatOrStringParams
      */
-    function test_export_call_works_when_calling_export_with_float_params($start, $count) {
+    function test_export_call_works_when_calling_export_with_float_or_string_params($start, $count) {
         $outputXmlHelper = new OutputXMLHelper();
         $this->assertEquals(false, $outputXmlHelper->paramsValid($start, $count), 'Expected float params should be invalid.');
     }
 
-    public function parameterProviderForXMLCallWithFloatParams()
+    public function parameterProviderForXMLCallWithFloatOrStringParams()
     {
         return [
             'invalid start = 13.37 and count = 1.2' => [13.37, 1.2],
             'invalid start = 22.5 and count = 01.22' => [22.5, 01.22],
             'invalid start = 55.2 and count = 2' => [55.2, 2],
             'invalid start = 22.4 and count = 300' => [22.4, 300],
-            'invalid start = 1.1 and count = 02.00' => [1.1, 02.00]
+            'invalid start = 1.1 and count = 02.00' => [1.1, 02.00],
+            'start = "1" and count = "10"' => ['1', '10']
         ];
     }
 }

--- a/_test/outputxmlhelper.test.php
+++ b/_test/outputxmlhelper.test.php
@@ -27,7 +27,7 @@ class outputxmlhelper_test extends DokuWikiTest
      */
     function test_export_call_with_params($start, $count) {
         $outputXmlHelper = new OutputXMLHelper();
-        $this->assertEquals(true, $outputXmlHelper->paramsValid($start, $count, FILTER_VALIDATE_INT), 'Expected params should be valid.');
+        $this->assertEquals(true, $outputXmlHelper->paramsValid($start, $count), 'Expected params should be valid.');
         $outputXmlHelper->getXml($start, $count);
     }
 
@@ -53,7 +53,7 @@ class outputxmlhelper_test extends DokuWikiTest
     function test_export_call_works_when_calling_export_with_invalid_params($start, $count) {
         $outputXmlHelper = new OutputXMLHelper();
         try {
-            $this->assertEquals(false, $outputXmlHelper->paramsValid($start, $count, FILTER_VALIDATE_INT), 'Expected params should be invalid.');
+            $this->assertEquals(false, $outputXmlHelper->paramsValid($start, $count), 'Expected params should be invalid.');
             $outputXmlHelper->getXml($start, $count);
             $this->fail('Invalid params should be recognized as invalid.');
         } catch (\InvalidArgumentException $e) {
@@ -79,7 +79,7 @@ class outputxmlhelper_test extends DokuWikiTest
      */
     function test_export_call_works_when_calling_export_with_float_or_string_params($start, $count) {
         $outputXmlHelper = new OutputXMLHelper();
-        $this->assertEquals(false, $outputXmlHelper->paramsValid($start, $count, FILTER_VALIDATE_INT), 'Expected float params should be invalid.');
+        $this->assertEquals(false, $outputXmlHelper->paramsValid($start, $count), 'Expected float params should be invalid.');
     }
 
     public function parameterProviderForXMLCallWithFloatOrStringParams()

--- a/_test/outputxmlhelper.test.php
+++ b/_test/outputxmlhelper.test.php
@@ -5,7 +5,7 @@ require_once(__DIR__ . '/../OutputXMLHelper.php');
 require_once(__DIR__ . '/../admin.php');
 require_once(__DIR__ . '/../_test/Helper.php');
 
-class output_xmlhelper_test extends DokuWikiTest
+class outputxmlhelper_test extends DokuWikiTest
 {
     public function setUp()
     {
@@ -21,7 +21,7 @@ class output_xmlhelper_test extends DokuWikiTest
      */
     function test_export_call_with_params($start, $count) {
         $outputXmlHelper = new OutputXMLHelper();
-        $this->assertEquals(true, $outputXmlHelper->paramsValid($start, $count), 'Expected params should be valid.');
+        $this->assertEquals(true, $outputXmlHelper->paramsValid($start, $count, FILTER_VALIDATE_INT), 'Expected params should be valid.');
         $outputXmlHelper->getXml($start, $count);
     }
 
@@ -32,7 +32,8 @@ class output_xmlhelper_test extends DokuWikiTest
             'start = 1 and count = 1' => [1, 1],
             'start = 10 and count = 1' => [10, 1],
             'start = 1 and count = 2' => [1, 2],
-            'start = 1 and count = 10' => [1, 10]
+            'start = 1 and count = 10' => [1, 10],
+            'start = "1" and count = "10"' => ['1', '10']
         ];
     }
 
@@ -46,7 +47,7 @@ class output_xmlhelper_test extends DokuWikiTest
     function test_export_call_works_when_calling_export_with_invalid_params($start, $count) {
         $outputXmlHelper = new OutputXMLHelper();
         try {
-            $this->assertEquals(false, $outputXmlHelper->paramsValid($start, $count), 'Expected params should be invalid.');
+            $this->assertEquals(false, $outputXmlHelper->paramsValid($start, $count, FILTER_VALIDATE_INT), 'Expected params should be invalid.');
             $outputXmlHelper->getXml($start, $count);
             $this->fail('Invalid params should be recognized as invalid.');
         } catch (\InvalidArgumentException $e) {
@@ -72,7 +73,7 @@ class output_xmlhelper_test extends DokuWikiTest
      */
     function test_export_call_works_when_calling_export_with_float_or_string_params($start, $count) {
         $outputXmlHelper = new OutputXMLHelper();
-        $this->assertEquals(false, $outputXmlHelper->paramsValid($start, $count), 'Expected float params should be invalid.');
+        $this->assertEquals(false, $outputXmlHelper->paramsValid($start, $count, FILTER_VALIDATE_INT), 'Expected float params should be invalid.');
     }
 
     public function parameterProviderForXMLCallWithFloatOrStringParams()
@@ -82,8 +83,7 @@ class output_xmlhelper_test extends DokuWikiTest
             'invalid start = 22.5 and count = 01.22' => [22.5, 01.22],
             'invalid start = 55.2 and count = 2' => [55.2, 2],
             'invalid start = 22.4 and count = 300' => [22.4, 300],
-            'invalid start = 1.1 and count = 02.00' => [1.1, 02.00],
-            'start = "1" and count = "10"' => ['1', '10']
+            'invalid start = 1.1 and count = 02.00' => [1.1, 02.00]
         ];
     }
 }

--- a/_test/outputxmlhelper.test.php
+++ b/_test/outputxmlhelper.test.php
@@ -27,7 +27,7 @@ class outputxmlhelper_test extends DokuWikiTest
      */
     function test_export_call_with_params($start, $count) {
         $outputXmlHelper = new OutputXMLHelper();
-        $this->assertEquals(true, $outputXmlHelper->paramsValid($start, $count), 'Expected params should be valid.');
+        $this->assertEquals(true, $outputXmlHelper->paramsValid($start, $count, FILTER_VALIDATE_INT), 'Expected params should be valid.');
         $outputXmlHelper->getXml($start, $count);
     }
 
@@ -53,7 +53,7 @@ class outputxmlhelper_test extends DokuWikiTest
     function test_export_call_works_when_calling_export_with_invalid_params($start, $count) {
         $outputXmlHelper = new OutputXMLHelper();
         try {
-            $this->assertEquals(false, $outputXmlHelper->paramsValid($start, $count), 'Expected params should be invalid.');
+            $this->assertEquals(false, $outputXmlHelper->paramsValid($start, $count, FILTER_VALIDATE_INT), 'Expected params should be invalid.');
             $outputXmlHelper->getXml($start, $count);
             $this->fail('Invalid params should be recognized as invalid.');
         } catch (\InvalidArgumentException $e) {
@@ -79,7 +79,7 @@ class outputxmlhelper_test extends DokuWikiTest
      */
     function test_export_call_works_when_calling_export_with_float_or_string_params($start, $count) {
         $outputXmlHelper = new OutputXMLHelper();
-        $this->assertEquals(false, $outputXmlHelper->paramsValid($start, $count), 'Expected float params should be invalid.');
+        $this->assertEquals(false, $outputXmlHelper->paramsValid($start, $count, FILTER_VALIDATE_INT), 'Expected float params should be invalid.');
     }
 
     public function parameterProviderForXMLCallWithFloatOrStringParams()

--- a/_test/outputxmlhelper.test.php
+++ b/_test/outputxmlhelper.test.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * General tests for the findologicxmlexport plugin
+ *
+ * @group plugin_findologicxmlexport
+ * @group plugins
+ */
 
 require_once(__DIR__ . '/../DokuwikiXMLExport.php');
 require_once(__DIR__ . '/../OutputXMLHelper.php');

--- a/_test/outputxmlhelper.test.php
+++ b/_test/outputxmlhelper.test.php
@@ -1,10 +1,11 @@
 <?php
 
+require_once(__DIR__ . '/../DokuwikiXMLExport.php');
 require_once(__DIR__ . '/../OutputXMLHelper.php');
 require_once(__DIR__ . '/../admin.php');
 require_once(__DIR__ . '/../_test/Helper.php');
 
-class outputxmlhelper_test extends DokuWikiTest
+class output_xmlhelper_test extends DokuWikiTest
 {
     public function setUp()
     {

--- a/_test/outputxmlhelper.test.php
+++ b/_test/outputxmlhelper.test.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once(__DIR__ . '/../OutputXMLHelper.php');
+require_once(__DIR__ . '/../admin.php');
 require_once(__DIR__ . '/../_test/Helper.php');
 
 class outputxmlhelper_test extends DokuWikiTest

--- a/index.php
+++ b/index.php
@@ -8,10 +8,10 @@
 require_once(__DIR__ . '/OutputXMLHelper.php');
 $outputXmlHelper = new OutputXMLHelper();
 // Get URL params
-$start = (int)$outputXmlHelper->getUrlParam($outputXmlHelper::START_NAME, $outputXmlHelper::DEFAULT_START_VALUE, $_GET, FILTER_VALIDATE_INT);
-$count = (int)$outputXmlHelper->getUrlParam($outputXmlHelper::COUNT_NAME, $outputXmlHelper::DEFAULT_COUNT_VALUE, $_GET, FILTER_VALIDATE_INT);
+$start = $outputXmlHelper->getUrlParam($outputXmlHelper::START_NAME, $outputXmlHelper::DEFAULT_START_VALUE, $_GET);
+$count = $outputXmlHelper->getUrlParam($outputXmlHelper::COUNT_NAME, $outputXmlHelper::DEFAULT_COUNT_VALUE, $_GET);
 // Check if params are valid and return the XML with the corresponding header
-if ($outputXmlHelper->paramsValid($start, $count)) {
+if ($outputXmlHelper->paramsValid($start, $count, FILTER_VALIDATE_INT)) {
     $outputXmlHelper->printXml($start, $count);
 } else {
     $outputXmlHelper->throwError();

--- a/index.php
+++ b/index.php
@@ -8,8 +8,8 @@
 require_once(__DIR__ . '/OutputXMLHelper.php');
 $outputXmlHelper = new OutputXMLHelper();
 // Get URL params
-$start = $outputXmlHelper->getUrlParam($outputXmlHelper::START_NAME, $outputXmlHelper::DEFAULT_START_VALUE, $_GET);
-$count = $outputXmlHelper->getUrlParam($outputXmlHelper::COUNT_NAME, $outputXmlHelper::DEFAULT_COUNT_VALUE, $_GET);
+$start = (int)$outputXmlHelper->getUrlParam($outputXmlHelper::START_NAME, $outputXmlHelper::DEFAULT_START_VALUE, $_GET);
+$count = (int)$outputXmlHelper->getUrlParam($outputXmlHelper::COUNT_NAME, $outputXmlHelper::DEFAULT_COUNT_VALUE, $_GET);
 // Check if params are valid and return the XML with the corresponding header
 if ($outputXmlHelper->paramsValid($start, $count)) {
     header($outputXmlHelper::EXPORT_HEADER);

--- a/index.php
+++ b/index.php
@@ -8,13 +8,11 @@
 require_once(__DIR__ . '/OutputXMLHelper.php');
 $outputXmlHelper = new OutputXMLHelper();
 // Get URL params
-$start = (int)$outputXmlHelper->getUrlParam($outputXmlHelper::START_NAME, $outputXmlHelper::DEFAULT_START_VALUE, $_GET);
-$count = (int)$outputXmlHelper->getUrlParam($outputXmlHelper::COUNT_NAME, $outputXmlHelper::DEFAULT_COUNT_VALUE, $_GET);
+$start = (int)$outputXmlHelper->getUrlParam($outputXmlHelper::START_NAME, $outputXmlHelper::DEFAULT_START_VALUE, $_GET, FILTER_VALIDATE_INT);
+$count = (int)$outputXmlHelper->getUrlParam($outputXmlHelper::COUNT_NAME, $outputXmlHelper::DEFAULT_COUNT_VALUE, $_GET, FILTER_VALIDATE_INT);
 // Check if params are valid and return the XML with the corresponding header
 if ($outputXmlHelper->paramsValid($start, $count)) {
-    header($outputXmlHelper::EXPORT_HEADER);
-    echo $outputXmlHelper->getXml($start, $count);
+    $outputXmlHelper->printXml($start, $count);
 } else {
-    header($outputXmlHelper::EXPORT_ERROR_HEADER, true, $outputXmlHelper::EXPORT_ERROR_CODE);
-    die($outputXmlHelper::EXPORT_ERROR_MESSAGE);
+    $outputXmlHelper->throwError();
 }


### PR DESCRIPTION
We are checking for `is_int()`, but the _GET param always returns a string, wich results in an error when setting a valid param like `start=0`.